### PR TITLE
Using https instead of git protocol for modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "external/glfw"]
 	path = external/glfw
-	url = git@github.com:glfw/glfw.git
+	url = https://github.com/glfw/glfw.git
 [submodule "external/glm"]
 	path = external/glm
-	url = git@github.com:g-truc/glm.git
+	url = https://github.com/g-truc/glm.git
 [submodule "external/glew"]
 	path = external/glew
-	url = git@github.com:nigels-com/glew.git
+	url = https://github.com/nigels-com/glew.git


### PR DESCRIPTION
I happen to have a stale SSH keypair that github gets upset about...
So I think HTTPS is more robust for fetch/clone, than git protocol.

```
$ git clone git@github.com:andersonfreitas/opengl-boilerplate.git --recursive
Cloning into 'opengl-boilerplate'...
ERROR: We're doing an SSH key audit.
Reason: unverified due to lack of use
Please visit https://github.com/settings/ssh/audit/.....
to approve this key so we know it's safe.
Fingerprint: 66:0e:7d:5a:bf:63:d1:c0:62:e3:ab:4b:..:..:6f:c6
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
